### PR TITLE
fix: correct API endpoint formatting for model prediction routes

### DIFF
--- a/docs/MODEL_SERVING_GUIDE.md
+++ b/docs/MODEL_SERVING_GUIDE.md
@@ -134,7 +134,7 @@ def _setup_api_routes(self):
         
         return jsonify({"model": models})
     
-    @self.flask_app.route('/v1/models/<model_name>:predict', methods=['POST'])
+    @self.flask_app.route('/v1/models/<model_name>/predict', methods=['POST'])
     def predict(model_name):
         """模型预测"""
         try:
@@ -583,7 +583,7 @@ FEATURE_DIMENSIONS = {
             print("📋 可用接口:")
             print("   - 健康检查: http://localhost:8501/health")
             print("   - 模型列表: http://localhost:8501/v1/models")
-            print("   - 预测接口: http://localhost:8501/v1/models/<model_name>:predict")
+            print("   - 预测接口: http://localhost:8501/v1/models/<model_name>/predict")
             print("   - 批量预测: http://localhost:8501/v1/models/<model_name>/batch_predict")
             print("=" * 50)
             

--- a/src/search_engine/model_service.py
+++ b/src/search_engine/model_service.py
@@ -481,7 +481,7 @@ class ModelService:
             print("📋 可用接口:")
             print("   - 健康检查: http://localhost:8501/health")
             print("   - 模型列表: http://localhost:8501/v1/models")
-            print("   - 预测接口: http://localhost:8501/v1/models/<model_name>:predict")
+            print("   - 预测接口: http://localhost:8501/v1/models/<model_name>/predict")
             print("   - 批量预测: http://localhost:8501/v1/models/<model_name>/batch_predict")
             print("=" * 50)
             
@@ -545,7 +545,7 @@ class ModelService:
             except Exception as e:
                 return jsonify({"error": str(e)}), 404
         
-        @self.flask_app.route('/v1/models/<model_name>:predict', methods=['POST'])
+        @self.flask_app.route('/v1/models/<model_name>/predict', methods=['POST'])
         def predict(model_name):
             """模型预测"""
             try:

--- a/start_system.py
+++ b/start_system.py
@@ -327,7 +327,7 @@ def check_and_start_model_service():
                     print("📋 可用接口:")
                     print("   - 健康检查: http://localhost:8501/health")
                     print("   - 模型列表: http://localhost:8501/v1/models")
-                    print("   - 预测接口: http://localhost:8501/v1/models/<model_name>:predict")
+                    print("   - 预测接口: http://localhost:8501/v1/models/<model_name>/predict")
                     print("   - 批量预测: http://localhost:8501/v1/models/<model_name>/batch_predict")
                     return True
         except Exception as e:


### PR DESCRIPTION
## Summary
Fix model prediction API route format by replacing non-standard colon syntax `:predict` with RESTful-compliant `/predict` path.

## Changes
- Core changes:
    - Updated prediction endpoint from `/v1/models/<model_name>:predict` to `/v1/models/<model_name>/predict`
    - Modified Flask route decorators and all related documentation 
- Impacted areas:
    - `model_service.py` - API route definition
    - `start_system.py` - Service startup logs
    - `MODEL_SERVING_GUIDE.md` - API documentation
- Breaking changes:
    - Yes - Existing clients must update API calls from `:predict` to `/predict`

## Checklist
- [x] Lint/format/test pass locally (ruff/black/pytest)
- [x] Tests added/updated as needed
- [x] Docs updated as needed

## Screenshots/Logs (if applicable)

## Related Issues
Fixes #

